### PR TITLE
Specify __all__ to fix `from win10toast import *`

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+__all__ = ['ToastNotifier']
+
 # #############################################################################
 # ########## Libraries #############
 # ##################################


### PR DESCRIPTION
before, this would clobber tonnes of things in the global namespace