### PR TITLE
Replace pywin32 requirement with pypiwin32.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ pypiwin32
 setuptools
 ```
 
-Easiest way to install pywin32 is using executable installer published at [https://sourceforge.net/projects/pywin32/files/pywin32/](https://sourceforge.net/projects/pywin32/files/pywin32/)
-
 ## Example
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install win10toast
 
 ### Installation of pywin32
 ```
-pywin32
+pypiwin32
 setuptools
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pywin32
+pypiwin32
 setuptools


### PR DESCRIPTION
[pywin32](https://pypi.python.org/pypi/pywin32) is not installable with pip since python version 3.4, so replacing it with [pypiwin32](https://pypi.python.org/pypi/pypiwin32) fixes installation for newer python versions over pip.
Please remember to update win10toast in the PyPi repositories after merging.