### PR TITLE
Add multithreading option for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,17 @@ setuptools
 from win10toast import ToastNotifier
 toaster = ToastNotifier()
 toaster.show_toast("Hello World!!!",
-              "Python is 10 seconds awsm!",
-              icon_path="custom.ico",
-              duration=10)
-toaster.show_toast("Hello World!!!",
-             "Python is awsm by default!")
+                   "Python is 10 seconds awsm!",
+                   icon_path="custom.ico",
+                   duration=10)
+
+toaster.show_toast("Example two",
+                   "This notification is in it's own thread!",
+                   icon_path=None,
+                   duration=5,
+                   threaded=True)
+# Wait for threaded notification to finish
+while toaster.notification_active(): time.sleep(0.1)
 ```
 
 

--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -9,6 +9,7 @@ __all__ = ['ToastNotifier']
 # ##################################
 # standard library
 import logging
+import threading
 from os import path
 from time import sleep
 from pkg_resources import Requirement
@@ -54,22 +55,12 @@ class ToastNotifier(object):
     from: https://github.com/jithurjacob/Windows-10-Toast-Notifications
     """
 
-    # def __init__(self):
-    #     """Initialize."""
-        # message_map = {WM_DESTROY: self.on_destroy, }
+    def __init__(self):
+        """Initialize."""
+        self._thread = None
 
-        # # Register the window class.
-        # self.wc = WNDCLASS()
-        # self.hinst = self.wc.hInstance = GetModuleHandle(None)
-        # self.wc.lpszClassName = str("PythonTaskbar")  # must be a string
-        # self.wc.lpfnWndProc = message_map  # could also specify a wndproc.
-        # try:
-        #     self.classAtom = RegisterClass(self.wc)
-        # except:
-        #     pass #not sure of this
-
-    def show_toast(self, title="Notification", msg="Here comes the message",
-                    icon_path=None, duration=5):
+    def _show_toast(self, title, msg,
+                    icon_path, duration):
         """Notification settings.
 
         :title: notification title
@@ -122,6 +113,33 @@ class ToastNotifier(object):
         DestroyWindow(self.hwnd)
         UnregisterClass(self.wc.lpszClassName, None)
         return None
+
+    def show_toast(self, title="Notification", msg="Here comes the message",
+                    icon_path=None, duration=5, threaded=False):
+        """Notification settings.
+
+        :title: notification title
+        :msg: notification message
+        :icon_path: path to the .ico file to custom notification
+        :duration: delay in seconds before notification self-destruction
+        """
+        if not threaded:
+            self._show_toast(title, msg, icon_path, duration)
+        else:
+            if self.notification_active():
+                # We have an active notification, let is finish so we don't spam them
+                return False
+
+            self._thread = threading.Thread(target=self._show_toast, args=(title, msg, icon_path, duration))
+            self._thread.start()
+        return True
+
+    def notification_active(self):
+        """See if we have an active notification showing"""
+        if self._thread != None and self._thread.is_alive():
+            # We have an active notification, let is finish we don't spam them
+            return True
+        return False
 
     def on_destroy(self, hwnd, msg, wparam, lparam):
         """Clean after notification ended.

--- a/win10toast/__main__.py
+++ b/win10toast/__main__.py
@@ -1,4 +1,5 @@
 ﻿from win10toast import ToastNotifier
+import time
 
 # #############################################################################
 # ###### Stand alone program ########
@@ -12,5 +13,10 @@ if __name__ == "__main__":
         duration=10)
     toaster.show_toast(
         "Example two",
-        "Once you start coding in Python you'll hate other languages",
+        "This notification is in it's own thread!",
+        icon_path=None,
+        duration=5,
+        threaded=True
         )
+    # Wait for threaded notification to finish
+    while toaster.notification_active(): time.sleep(0.1)


### PR DESCRIPTION
This allows notifications to optionally be launched in their own threads such that they do not block the rest of the application