### PR TITLE
Added on-click callback feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 
 from operator import attrgetter
 from os import path
+from setuptools import setup pi
 
-from pip.req import parse_requirements
-from setuptools import setup
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+
 
 def read(fname):
     return open(path.join(path.dirname(__file__), fname)).read()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
 from operator import attrgetter
 from os import path
-from setuptools import setup pi
+from setuptools import setup
 
 try: # for pip >= 10
     from pip._internal.req import parse_requirements

--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -66,7 +66,7 @@ class ToastNotifier(object):
         :title: notification title
         :msg: notification message
         :icon_path: path to the .ico file to custom notification
-        :duration: delay in seconds before notification self-destruction
+        :duration: delay in seconds before notification self-destruction, None for no-self-destruction
         """
         message_map = {WM_DESTROY: self.on_destroy, }
 
@@ -109,9 +109,10 @@ class ToastNotifier(object):
                                       hicon, "Balloon Tooltip", msg, 200,
                                       title))
         # take a rest then destroy
-        sleep(duration)
-        DestroyWindow(self.hwnd)
-        UnregisterClass(self.wc.lpszClassName, None)
+        if duration is not None:
+            sleep(duration)
+            DestroyWindow(self.hwnd)
+            UnregisterClass(self.wc.lpszClassName, None)
         return None
 
     def show_toast(self, title="Notification", msg="Here comes the message",
@@ -121,7 +122,7 @@ class ToastNotifier(object):
         :title: notification title
         :msg: notification message
         :icon_path: path to the .ico file to custom notification
-        :duration: delay in seconds before notification self-destruction
+        :duration: delay in seconds before notification self-destruction, None for no-self-destruction
         """
         if not threaded:
             self._show_toast(title, msg, icon_path, duration)

--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -94,8 +94,13 @@ class ToastNotifier(object):
         self.wc.lpfnWndProc = self._decorator(self.wnd_proc, callback_on_click)  # could instead specify simple mapping
         try:
             self.classAtom = RegisterClass(self.wc)
+<<<<<<< HEAD
         except (TypeError, Exception):
             pass  # not sure of this
+=======
+        except Exception as e:
+            logging.error("Some trouble with classAtom ({})".format(e))
+>>>>>>> f1db5b2... https://github.com/jithurjacob/Windows-10-Toast-Notifications/issues/33 added logging to classAtom
         style = WS_OVERLAPPED | WS_SYSMENU
         self.hwnd = CreateWindow(self.classAtom, "Taskbar", style,
                                  0, 0, CW_USEDEFAULT,

--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -94,13 +94,8 @@ class ToastNotifier(object):
         self.wc.lpfnWndProc = self._decorator(self.wnd_proc, callback_on_click)  # could instead specify simple mapping
         try:
             self.classAtom = RegisterClass(self.wc)
-<<<<<<< HEAD
-        except (TypeError, Exception):
-            pass  # not sure of this
-=======
         except Exception as e:
             logging.error("Some trouble with classAtom ({})".format(e))
->>>>>>> f1db5b2... https://github.com/jithurjacob/Windows-10-Toast-Notifications/issues/33 added logging to classAtom
         style = WS_OVERLAPPED | WS_SYSMENU
         self.hwnd = CreateWindow(self.classAtom, "Taskbar", style,
                                  0, 0, CW_USEDEFAULT,


### PR DESCRIPTION
Hi.
I added callback on click functionality discussed in [this issue ](https://github.com/jithurjacob/Windows-10-Toast-Notifications/issues/3) .
Implementation followed [this](https://github.com/jithurjacob/Windows-10-Toast-Notifications/issues/3#issuecomment-385175355) comment plus my own code snippet for decorator/handler.

How it works - just add to `show_toast` method argument called `callback_on_click` with callable as value. 