### PR TITLE
Show permanent toast if `duration` is None

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -66,7 +66,7 @@ class ToastNotifier(object):
         :title: notification title
         :msg: notification message
         :icon_path: path to the .ico file to custom notification
-        :duration: delay in seconds before notification self-destruction
+        :duration: delay in seconds before notification self-destruction, None for no-self-destruction
         """
         message_map = {WM_DESTROY: self.on_destroy, }
 
@@ -109,9 +109,10 @@ class ToastNotifier(object):
                                       hicon, "Balloon Tooltip", msg, 200,
                                       title))
         # take a rest then destroy
-        sleep(duration)
-        DestroyWindow(self.hwnd)
-        UnregisterClass(self.wc.lpszClassName, None)
+        if duration is not None:
+            sleep(duration)
+            DestroyWindow(self.hwnd)
+            UnregisterClass(self.wc.lpszClassName, None)
         return None
 
     def show_toast(self, title="Notification", msg="Here comes the message",
@@ -121,7 +122,7 @@ class ToastNotifier(object):
         :title: notification title
         :msg: notification message
         :icon_path: path to the .ico file to custom notification
-        :duration: delay in seconds before notification self-destruction
+        :duration: delay in seconds before notification self-destruction, None for no-self-destruction
         """
         if not threaded:
             self._show_toast(title, msg, icon_path, duration)


### PR DESCRIPTION
Hi,

Currently all toasts will be destructed after a few seconds, but sometimes we need to show permanent toasts, namely toasts that will not be automatically destructed, even after the program exits.

Now we can pass `duration=None` to specify that we do not want our toasts to be automatically destructed.
