### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pypiwin32
+pywin32
 setuptools


### PR DESCRIPTION
Since pypiwin32 is deprecated
> Note: the "pypiwin32" project has ended; it's now simply a shim package that requires "pywin32".
see: https://github.com/mhammond/pywin32/issues/1151
Further more it will conflict with the current installed `pywin32`