### PR TITLE
Added Title Support For systray icon , Syntax highlighting in README and a few spelling Corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ setuptools
 
 ## Example
 
-```
+```py
 from win10toast import ToastNotifier
 toaster = ToastNotifier()
 toaster.show_toast("Hello World!!!",

--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -137,7 +137,7 @@ class ToastNotifier(object):
     def notification_active(self):
         """See if we have an active notification showing"""
         if self._thread != None and self._thread.is_alive():
-            # We have an active notification, let is finish we don't spam them
+            # We have an active notification, let it finish so we don't spam them
             return True
         return False
 

--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -55,9 +55,10 @@ class ToastNotifier(object):
     from: https://github.com/jithurjacob/Windows-10-Toast-Notifications
     """
 
-    def __init__(self):
+    def __init__(self, application_name = None):
         """Initialize."""
         self._thread = None
+        self.application_name = application_name or "Tooltip"
 
     def _show_toast(self, title, msg,
                     icon_path, duration):
@@ -102,7 +103,7 @@ class ToastNotifier(object):
 
         # Taskbar icon
         flags = NIF_ICON | NIF_MESSAGE | NIF_TIP
-        nid = (self.hwnd, 0, flags, WM_USER + 20, hicon, "Tooltip")
+        nid = (self.hwnd, 0, flags, WM_USER + 20, hicon, self.application_name)
         Shell_NotifyIcon(NIM_ADD, nid)
         Shell_NotifyIcon(NIM_MODIFY, (self.hwnd, 0, NIF_INFO,
                                       WM_USER + 20,


### PR DESCRIPTION
Made it possible to add a title of your own for the systray icon rather than just `tooltip`.
example:
```py
from win10toast import ToastNotifier

notifier = ToastNotifier("Application Name")
notifier.show_toast(
    "Notification",
    "Message",
    icon_path = "Keyboard A Key.ico",
    duration = 10,
    threaded = True)
```

![image](https://user-images.githubusercontent.com/64970593/128671316-8ce9c7f3-c33a-4dff-9d48-1bd923b8382d.png)
Also did a few spelling corrections.(In README and __init__)