### PR TITLE
Fixed bug in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'win10toast': ['data/*.ico'],
     },
     long_description=read('README.md'),
+    long_description_content_type="text/markdown",
     author="Jithu R Jacob",
     author_email="jithurjacob@gmail.com",
     classifiers=[


### PR DESCRIPTION
The markdown file would now be rendered in the pypi page,
instead of appearing as a text file