### PR TITLE
support running many times in loop with one instance

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -152,6 +152,11 @@ class ToastNotifier(object):
     def destroy(self):
         DestroyWindow(self.hwnd)
         UnregisterClass(self.wc.lpszClassName, None)
+        self.hwnd = None
+        self.nid = None
+        self._thread = None
+        self.wc = None
+        self.hicon = None
 
     def on_destroy(self, hwnd, msg, wparam, lparam):
         """Clean after notification ended.

--- a/win10toast/__main__.py
+++ b/win10toast/__main__.py
@@ -5,18 +5,26 @@ import time
 # ###### Stand alone program ########
 # ###################################
 if __name__ == "__main__":
-    # Example
+    # Example simple use
     toaster = ToastNotifier()
     toaster.show_toast(
         "Hello World!!!",
-        "Python is 10 seconds awsm!",
-        duration=10)
+        "Python is 10 seconds awsm!")
+    toaster.destroy()
+    
+    # Example with case
+    with toaster:
+        toaster.show_toast(
+            "Hello World!!!",
+            "Python is 10 seconds awsm!")
+
+    # Example with threaded
     toaster.show_toast(
         "Example two",
         "This notification is in it's own thread!",
         icon_path=None,
-        duration=5,
         threaded=True
         )
     # Wait for threaded notification to finish
     while toaster.notification_active(): time.sleep(0.1)
+    toaster.destroy()


### PR DESCRIPTION
fix bug when 
```
for i in range(0, 100):
    toaster.show_toast(...., duration=300)
    time.sleep(1)
```
and program create window instance many times

and remove destroy window after toast show.
now window will be destroy after this:
```
toast.destroy()
```
or
```
with CustomToastNotifier() as toaster:
    toaster....
```
text codes:
```
import time


count = 0
with CustomToastNotifier() as toaster:
    while True:
        time.sleep(3)
        toaster.show_toast("Hello World!!!",
                           "Python is 10 seconds awsm!",
                           icon_path="custom.ico",
                           duration=100)
        count += 1
        if count >= 5:
            break
```