### PR TITLE
`WM_DESTROY` callback must return 0 (fixes TypeError from `show_toast()`)

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -143,6 +143,8 @@ class ToastNotifier(object):
 
     def on_destroy(self, hwnd, msg, wparam, lparam):
         """Clean after notification ended.
+        
+        See https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-destroy#return-value
 
         :hwnd:
         :msg:
@@ -153,5 +155,5 @@ class ToastNotifier(object):
         Shell_NotifyIcon(NIM_DELETE, nid)
         PostQuitMessage(0)
 
-        return None
+        return 0
 


### PR DESCRIPTION
fixes #112

The `on_destroy` method that's called as part of the `WM_DESTROY` callback must return 0, not none. Otherwise this error will raise when using `show_toast()`:

```
TypeError: WPARAM is simple, so must be an int object (got NoneType)
```