### PR TITLE
Updated imports for pip version 23.0.1, fixed attrgetter input

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,20 @@
 from operator import attrgetter
 from os import path
 
-from pip.req import parse_requirements
+#from pip.req import parse_requirements
+try:
+    # pip >=20
+    #from pip._internal.network.session import PipSession
+    from pip._internal.req import parse_requirements
+except ImportError:
+    try:
+        # 10.0.0 <= pip <= 19.3.1
+        #from pip._internal.download import PipSession
+        from pip._internal.req import parse_requirements
+    except ImportError:
+        # pip <= 9.0.3
+        #from pip.download import PipSession
+        from pip.req import parse_requirements
 from setuptools import setup
 
 def read(fname):
@@ -14,7 +27,7 @@ def from_here(relative_path):
 
 
 requirements_txt = list(map(str, map(
-    attrgetter("req"),
+    attrgetter("requirement"),
     parse_requirements(from_here("requirements.txt"), session="")
 )))
 

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,20 @@
 
 from operator import attrgetter
 from os import path
+from setuptools import setup
 
-#from pip.req import parse_requirements
 try:
     # pip >=20
-    #from pip._internal.network.session import PipSession
     from pip._internal.req import parse_requirements
 except ImportError:
     try:
         # 10.0.0 <= pip <= 19.3.1
-        #from pip._internal.download import PipSession
         from pip._internal.req import parse_requirements
     except ImportError:
         # pip <= 9.0.3
-        #from pip.download import PipSession
         from pip.req import parse_requirements
-from setuptools import setup
+
+
 
 def read(fname):
     return open(path.join(path.dirname(__file__), fname)).read()


### PR DESCRIPTION
The project couldn't be bulit into a .whl file without this changes. 

`ModuleNotFoundError: No module named 'pip.req'`

`AttributeError: 'ParsedRequirement' object has no attribute 'req'`

Found this trying to fix issue #114 , although his issue seems to come from a python's 3.12 build method scripting error.