### PR TITLE
(IMPORTANT) Fix __init__.py Error "WNDPROC return value cannot be converted to LRESULT TypeError: WPARAM is simple, so must be an int object (got NoneType)"

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -153,5 +153,5 @@ class ToastNotifier(object):
         Shell_NotifyIcon(NIM_DELETE, nid)
         PostQuitMessage(0)
 
-        return None
+        return 0  # Error fixed (WNDPROC return value cannot be converted to LRESULT TypeError: WPARAM is simple, so must be an int object (got NoneType))
 


### PR DESCRIPTION
ERROR: WNDPROC return value cannot be converted to LRESULT TypeError: WPARAM is simple, so must be an int object (got NoneType)

FIX: The error "WNDPROC return value cannot be converted to LRESULT TypeError: WPARAM is simple, so must be an int object (got NoneType)" is occurring because the `on_destroy` method is not returning any value explicitly, and as a result, it returns `None` by default. However, in this case, `on_destroy` should return an integer value (`LRESULT`). To fix the issue, you can add `return 0` at the end of the `on_destroy` method to explicitly return 0.

Here's the modified `on_destroy` method:

```python
def on_destroy(self, hwnd, msg, wparam, lparam):
    """Clean after notification ended.

    :hwnd:
    :msg:
    :wparam:
    :lparam:
    """
    nid = (self.hwnd, 0)
    Shell_NotifyIcon(NIM_DELETE, nid)
    PostQuitMessage(0)

    return 0  # Explicitly return 0 to fix the error
```

With this change, the `on_destroy` method will now return an integer value (`LRESULT`) as expected, and the error should be resolved.